### PR TITLE
Adding ability to search by using SKU, UPC, EAN and ISBN.

### DIFF
--- a/lib/ApaiIO/Operations/Lookup.php
+++ b/lib/ApaiIO/Operations/Lookup.php
@@ -46,4 +46,54 @@ class Lookup extends AbstractOperation
 
         return $this;
     }
+
+    /**
+     * Sets the idtype either ASIN (Default), SKU, UPC, EAN, and ISBN
+     *
+     * @param string $idType
+     *
+     * @return \ApaiIO\Operations\Lookup
+     */
+    public function setIdType($idType)
+    {
+    	$idType = strtoupper($idType);
+
+    	switch($idType) {
+    		case 'SKU':
+    		case 'EAN':
+    			break;
+    		case 'UPC':
+    			// UPC is not valid in the CA locale
+    			break;
+    		case 'ISBN':
+    			// US Only.
+    			break;
+
+    		// Prevent Invalid idtype
+    		default:
+    			$idType = 'ASIN';
+    	}
+
+        $this->parameter['IdType'] = $idType;
+
+        if (empty($this->parameter['SearchIndex'])) {
+        	$this->parameter['SearchIndex'] = 'All';
+        }
+
+        return $this;
+    }
+
+    /**
+     * Sets the searchindex which should be used when set IdType other than ASIN
+     *
+     * @param string $searchIndex
+     *
+     * @return \ApaiIO\Operations\Lookup
+     */
+    public function setSearchIndex($searchIndex)
+    {
+        $this->parameter['SearchIndex'] = $searchIndex;
+
+        return $this;
+    }
 }

--- a/tests/ApaiIO/Test/Operations/Types/LookupTest.php
+++ b/tests/ApaiIO/Test/Operations/Types/LookupTest.php
@@ -33,4 +33,25 @@ class LookupTest extends \PHPUnit_Framework_TestCase
         $lookup = new Lookup();
         $this->assertEquals('ItemLookup', $lookup->getName());
     }
+
+    public function testGetIdType()
+    {
+    	$lookup = new Lookup();
+    	$lookup->setIdType('UPC');
+        $this->assertEquals('UPC', $lookup->getIdType());
+        $this->assertEquals('All', $lookup->getSearchIndex());
+        $lookup->setIdType('upc');
+        $this->assertEquals('UPC', $lookup->getIdType());
+        $this->assertEquals('All', $lookup->getSearchIndex());
+        $lookup->setIdType('not valid');
+        $this->assertEquals('ASIN', $lookup->getIdType());
+        $this->assertEquals('All', $lookup->getSearchIndex());
+    }
+
+    public function testGetSearchIndex()
+    {
+    	$lookup = new Lookup();
+    	$lookup->setSearchIndex('Appliances');
+        $this->assertEquals('Appliances', $lookup->getSearchIndex());
+    }
 }


### PR DESCRIPTION
I would like to add a new feature to be able to search using other ID type (not just ASIN).

Reference:
http://docs.aws.amazon.com/AWSECommerceService/latest/DG/ItemLookup.html
http://docs.aws.amazon.com/AWSECommerceService/latest/DG/APPNDX_SearchIndexValues.html

All test passed.

Thank you.
