### PR TITLE
Update Lookup.php

### DIFF
--- a/lib/ApaiIO/Operations/Lookup.php
+++ b/lib/ApaiIO/Operations/Lookup.php
@@ -80,8 +80,8 @@ class Lookup extends AbstractOperation
 
         $this->parameter['IdType'] = $idType;
 
-        if (empty($this->parameter['SearchIndex'])) {
-        	$this->parameter['SearchIndex'] = 'All';
+        if($idType != self::TYPE_ASIN){
+            $this->parameter['SearchIndex'] = 'All';
         }
 
         return $this;


### PR DESCRIPTION
Whilst using this library and amazon's advertising product API I've come across the following errors: 

"Message":"Your request contained a restricted parameter combination. When IdType equals ASIN, SearchIndex cannot be present."
and 
"Your request is missing a required parameter combination. When IdType equals ['DPCI', 'SKU',\n\t\t\t\t'UPC', 'EAN','ISBN'], SearchIndex must be present."

as such I've modified Apai-io locally to the same as this commit