### PR TITLE
Added missing line to example code

### DIFF
--- a/installation.html
+++ b/installation.html
@@ -67,6 +67,8 @@
 use ApaiIO\Configuration\GenericConfiguration;
 use ApaiIO\ApaiIO;
 
+$conf = new GenericConfiguration();
+
 $conf
     ->setCountry('com')
     ->setAccessKey('YOUR ACCESS KEY')


### PR DESCRIPTION
`$conf` is undeclared in the doc.
