### PR TITLE
Add setCondition() to Search and Lookup

### DIFF
--- a/lib/ApaiIO/Operations/Lookup.php
+++ b/lib/ApaiIO/Operations/Lookup.php
@@ -100,4 +100,20 @@ class Lookup extends AbstractOperation
 
         return $this;
     }
+
+    /**
+     * Sets the condition of the items to return: New | Used | Collectible | Refurbished | All
+     *
+     * Defaults to New.
+     *
+     * @param string $condition
+     *
+     * @return \ApaiIO\Operations\Lookup
+     */
+    public function setCondition($condition)
+    {
+        $this->parameter['Condition'] = $condition;
+
+        return $this;
+    }
 }

--- a/lib/ApaiIO/Operations/Search.php
+++ b/lib/ApaiIO/Operations/Search.php
@@ -120,6 +120,22 @@ class Search extends AbstractOperation
     }
 
     /**
+     * Sets the condition of the items to return: New | Used | Collectible | Refurbished | All
+     *
+     * Defaults to New.
+     *
+     * @param string $condition
+     *
+     * @return \ApaiIO\Operations\Search
+     */
+    public function setCondition($condition)
+    {
+        $this->parameter['Condition'] = $condition;
+
+        return $this;
+    }
+
+    /**
      * Validates the given price.
      *
      * @param integer $price

--- a/tests/ApaiIO/Test/Operations/Types/LookupTest.php
+++ b/tests/ApaiIO/Test/Operations/Types/LookupTest.php
@@ -70,4 +70,11 @@ class LookupTest extends \PHPUnit_Framework_TestCase
         $lookup->setSearchIndex('Appliances');
         $this->assertEquals('Appliances', $lookup->getSearchIndex());
     }
+
+    public function testConditionGetterAndSetter()
+    {
+        $lookup = new Lookup();
+        $lookup->setCondition('All');
+        $this->assertEquals('All', $lookup->getCondition());
+    }
 }

--- a/tests/ApaiIO/Test/Operations/Types/SearchTest.php
+++ b/tests/ApaiIO/Test/Operations/Types/SearchTest.php
@@ -75,4 +75,11 @@ class SearchTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(1, $search->getItemPage());
     }
+
+    public function testConditionGetterAndSetter()
+    {
+        $search = new Search();
+        $search->setCondition('All');
+        $this->assertEquals('All', $search->getCondition());
+    }
 }


### PR DESCRIPTION
[ItemSearch](http://docs.aws.amazon.com/AWSECommerceService/latest/DG/ItemSearch.html) and [ItemLookup](http://docs.aws.amazon.com/AWSECommerceService/latest/DG/ItemLookup.html) both have an optional `Condition` parameter that can be set to 'New', 'Used', 'All', etc.

This PR adds explicit setters to `Search` and `Lookup` classes for this parameter.
