### PR TITLE
Adding BaseConfiguration class providing a set of magic methods to accesses setters and getters as properties.

### DIFF
--- a/lib/ApaiIO/Configuration/BaseConfiguration.php
+++ b/lib/ApaiIO/Configuration/BaseConfiguration.php
@@ -1,0 +1,115 @@
+<?php
+/*
+ * Copyright 2014 Alexander Stepanov <student_vmk@mail.ru>
+ * Code of magic methods is pretty much a copy-paste from yii/base/Object
+ * implementation in yii2 framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace ApaiIO\Configuration;
+
+/**
+ * A set of magic methods to access setters and getters as properties
+ *
+ * @author Alexander Stepanov <student_vmk@mail.ru>
+ */
+class BaseConfiguration
+{
+    /**
+     * Returns the value of an object property.
+     *
+     * Do not call this method directly as it is a PHP magic method that
+     * will be implicitly called when executing `$value = $object->property;`.
+     * @param string $name the property name
+     * @return mixed the property value
+     * @throws \Exception if the property is not defined
+     * @throws \BadMethodCallException if the property is write-only
+     * @see __set()
+     */
+    public function __get($name)
+    {
+        $getter = 'get' . $name;
+        if (method_exists($this, $getter)) {
+            return $this->$getter();
+        } elseif (method_exists($this, 'set' . $name)) {
+            throw new \BadMethodCallException('Getting write-only property: ' . get_class($this) . '::' . $name);
+        } else {
+            throw new \Exception('Getting unknown property: ' . get_class($this) . '::' . $name);
+        }
+    }
+
+    /**
+     * Sets value of an object property.
+     *
+     * Do not call this method directly as it is a PHP magic method that
+     * will be implicitly called when executing `$object->property = $value;`.
+     * @param string $name the property name or the event name
+     * @param mixed $value the property value
+     * @throws \Exception if the property is not defined
+     * @throws \BadMethodCallException if the property is read-only
+     * @see __get()
+     */
+    public function __set($name, $value)
+    {
+        $setter = 'set' . $name;
+        if (method_exists($this, $setter)) {
+            $this->$setter($value);
+        } elseif (method_exists($this, 'get' . $name)) {
+            throw new \BadMethodCallException('Setting read-only property: ' . get_class($this) . '::' . $name);
+        } else {
+            throw new \Exception('Setting unknown property: ' . get_class($this) . '::' . $name);
+        }
+    }
+
+    /**
+     * Checks if the named property is set (not null).
+     *
+     * Do not call this method directly as it is a PHP magic method that
+     * will be implicitly called when executing `isset($object->property)`.
+     *
+     * Note that if the property is not defined, false will be returned.
+     * @param string $name the property name or the event name
+     * @return boolean whether the named property is set (not null).
+     */
+    public function __isset($name)
+    {
+        $getter = 'get' . $name;
+        if (method_exists($this, $getter)) {
+            return $this->$getter() !== null;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Sets an object property to null.
+     *
+     * Do not call this method directly as it is a PHP magic method that
+     * will be implicitly called when executing `unset($object->property)`.
+     *
+     * Note that if the property is not defined, this method will do nothing.
+     * If the property is read-only, it will throw an exception.
+     * @param string $name the property name
+     * @throws \BadMethodCallException if the property is read only.
+     */
+    public function __unset($name)
+    {
+        $setter = 'set' . $name;
+        if (method_exists($this, $setter)) {
+            $this->$setter(null);
+        } elseif (method_exists($this, 'get' . $name)) {
+            throw new \BadMethodCallException('Unsetting read-only property: ' . get_class($this) . '::' . $name);
+        }
+    }
+}

--- a/lib/ApaiIO/Configuration/GenericConfiguration.php
+++ b/lib/ApaiIO/Configuration/GenericConfiguration.php
@@ -17,14 +17,12 @@
 
 namespace ApaiIO\Configuration;
 
-use ApaiIO\Configuration\Country;
-
 /**
  * A generic configurationclass
  *
  * @author Jan Eichhorn <exeu65@googlemail.com>
  */
-class GenericConfiguration implements ConfigurationInterface
+class GenericConfiguration extends BaseConfiguration implements ConfigurationInterface
 {
     /**
      * The country


### PR DESCRIPTION
Adding BaseConfiguration class providing a set of magic methods to access setters and getters as properties.

Useful e.g. in Yii2 framework as it allows to instantiate configuration as an application component. For example:

``` php
'ApaiIOConfig' => [
            'class' => 'ApaiIO\Configuration\GenericConfiguration',
            'accessKey' => 'your_access_key',
            'secretKey' => 'your_secret_key',
            'associateTag' => 'your_associate_tag',
            'country' => 'co.uk'
        ],
```

You can also access getters as properties in Yii this way, e.g.

``` php
$tag = Yii::$app->ApaiIOConfig->associateTag;
```

Also removed unnecessary  use statement from GenericConfiguration as Country class is located in the same namespace
