### PR TITLE
Fix issue when looking up by ASIN number

### DIFF
--- a/lib/ApaiIO/Operations/Lookup.php
+++ b/lib/ApaiIO/Operations/Lookup.php
@@ -80,7 +80,7 @@ class Lookup extends AbstractOperation
 
         $this->parameter['IdType'] = $idType;
 
-        if (empty($this->parameter['SearchIndex'])) {
+        if (empty($this->parameter['SearchIndex']) && $idType != self::TYPE_ASIN) {
             $this->parameter['SearchIndex'] = 'All';
         }
 

--- a/tests/ApaiIO/Test/Operations/Types/LookupTest.php
+++ b/tests/ApaiIO/Test/Operations/Types/LookupTest.php
@@ -56,6 +56,40 @@ class LookupTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider providerSetIdTypeAffectsSearchIndex
+     *
+     * @param string      $idType
+     * @param string|null $expectedSearchIndex
+     */
+    public function testSetIdTypeAffectsSearchIndex($idType, $expectedSearchIndex)
+    {
+        $lookup = new Lookup();
+        $lookup->setIdType($idType);
+
+        $parameters = $lookup->getOperationParameter();
+
+        if ($expectedSearchIndex === null) {
+            $this->assertArrayNotHasKey('SearchIndex', $parameters);
+        } else {
+            $this->assertSame($expectedSearchIndex, $parameters['SearchIndex']);
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function providerSetIdTypeAffectsSearchIndex()
+    {
+        return array(
+            array(Lookup::TYPE_ASIN, null),
+            array(Lookup::TYPE_SKU, 'All'),
+            array(Lookup::TYPE_UPC, 'All'),
+            array(Lookup::TYPE_EAN, 'All'),
+            array(Lookup::TYPE_ISBN, 'All')
+        );
+    }
+
+    /**
      * @expectedException InvalidArgumentException
      */
     public function testExceptionWhenPassingWrongIdType()


### PR DESCRIPTION
This prevents the following error: **AWS.RestrictedParameterValueCombination**

> Your request contained a restricted parameter combination.  When IdType equals ASIN, SearchIndex cannot be present.

Is there really a need to default the SearchIndex to 'All', by the way?