### PR TITLE
exceptions generated by the soapClient __soapCall now bubble up the library

### DIFF
--- a/lib/ApaiIO/ApaiIO.php
+++ b/lib/ApaiIO/ApaiIO.php
@@ -70,7 +70,11 @@ class ApaiIO
 
         $requestObject = RequestFactory::createRequest($configuration);
 
-        $response = $requestObject->perform($operation);
+        try {
+            $response = $requestObject->perform($operation);
+        } catch (\Exception $e) {
+            throw $e;
+        }
 
         return $this->applyResponseTransformer($response, $configuration);
     }

--- a/lib/ApaiIO/Request/Soap/Request.php
+++ b/lib/ApaiIO/Request/Soap/Request.php
@@ -64,7 +64,11 @@ class Request implements RequestInterface
     {
         $requestParams = $this->buildRequestParams($operation);
 
-        $result = $this->performSoapRequest($operation, $requestParams);
+        try {
+            $result = $this->performSoapRequest($operation, $requestParams);
+        } catch (\Exception $e) {
+            throw $e;
+        }
 
         return $result;
     }
@@ -149,7 +153,13 @@ class Request implements RequestInterface
         );
         $soapClient->__setSoapHeaders($this->buildSoapHeader($operation));
 
-        return $soapClient->__soapCall($operation->getName(), array($params));
+        try {
+            $result = $soapClient->__soapCall($operation->getName(), array($params));
+        } catch (\Exception $e) {
+            throw $e;
+        }
+
+        return $result;
     }
 
     /**


### PR DESCRIPTION
Often when using this library my scripts will just crash with a FATAL error if the request causes an Exception to occur, because you are not handling exceptions. More often than not this is caused by me making requests too quickly to the Amazon API.

This commit causes any exceptions generated to bubble up the library, in to the calling code, where they can then be handled appropriately. e.g.

        $soapSuccess = false;
        do {
            try {
                $response = $apaiIO->runOperation($lookup);
                $soapSuccess = true;
            } catch (\SoapFault $e) {
                $logger->error('SoapFault Exception Problem making Soap request to Amazon');
                $logger->error('SOAP fault code: ' . $e->faultcode);
                $logger->error($e -> getMessage());
                sleep(5 + rand(0,5));
            } catch (\Exception $e) {
                $logger->error('Exception Exception Problem making Soap request to Amazon');
                $logger->error('SOAP fault code: ' . $e->faultcode);
                $logger->error($e -> getMessage());
                sleep(5 + rand(0,5));
            }
        } while (!$soapSuccess);