### PR TITLE
Update API version in 2.0

### DIFF
--- a/RFC-VERSION-2-0.md
+++ b/RFC-VERSION-2-0.md
@@ -6,6 +6,7 @@ This document should collect all topics which are relevant for version 2.0
 - drop soap support (the soap request will be provided as separate package)
 - use a dedicated rest client as vendor
 - drop object to array response transformer
+- update API version from 2011-08-01 to 2013-08-01
 
 ## RFC
 Nothing so far.


### PR DESCRIPTION
Current Product Advertising API version is locked to `2011-08-01`, but the latest is `2013-08-01`:
http://docs.aws.amazon.com/AWSECommerceService/latest/DG/Welcome.html

Version 2.0 could be a good opportunity to use the latest version.