### PR TITLE
Speed up REST transfers with Content-Encoding

### DIFF
--- a/lib/ApaiIO/Request/Rest/Request.php
+++ b/lib/ApaiIO/Request/Rest/Request.php
@@ -60,6 +60,13 @@ class Request implements RequestInterface
     const USERAGENT = CURLOPT_USERAGENT;
 
     /**
+     * Content encoding; an empty string will use any supported encoding
+     *
+     * @var string
+     */
+    const ENCODING = CURLOPT_ENCODING;
+
+    /**
      * curl options
      *
      * @var array
@@ -89,7 +96,8 @@ class Request implements RequestInterface
             self::USERAGENT          => "ApaiIO [" . ApaiIO::VERSION . "]",
             self::CONNECTION_TIMEOUT => 10,
             self::TIMEOUT            => 10,
-            self::FOLLOW_LOCATION    => 1
+            self::FOLLOW_LOCATION    => 1,
+            self::ENCODING           => ''
         );
         $this->setOptions($options);
     }


### PR DESCRIPTION
REST request implementation is based on cURL, which is configured by default to not leverage HTTP compression.

Using `CURLOPT_ENCODING` allows cURL to send an `Accept-Encoding` header to inform the server that it accepts gzip and deflate encodings, so the server can reply with a `Content-Encoding` header and a compressed response.

This parameter is set to an empty string on purpose. According to [the manual](http://php.net/manual/en/function.curl-setopt.php):

> If an empty string, "", is set, a header containing all supported encoding types is sent.

---

This is especially useful with Amazon Product Advertising API, which can return large documents when using several response groups. My `ItemSearch` requests returning 10 items, for example, produce XML documents averaging 150 KiB.

On my server located in France, on a Gigabit connection to the rest of the world, querying the Amazon.com API (US west coast), the latency improvement when using HTTP compression is about 190 ms, which is quite interesting.

I measured it on 200 `ItemSearch` queries, with and without compression, taking the average difference between the measured duration of the query, and the `RequestProcessingTime` returned by Amazon in the XML document. The difference is the network latency + HTTP compression / decompression time, if any. Even with the added compression/decompression time, the benefit is real.

I guess this PR will benefit even consumers of the API located in the USA.