### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ php composer.phar install
 Composer will generate the autoloader file automaticly. So you only have to include this.
 Typically its located in the vendor dir and its called autoload.php
 
-##Basic Usage:
+## Basic Usage:
 This library is using the PSR-0 standard: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md
 So you can use any autoloader which fits into this standard.
 The tests directory contains an example bootstrap file.
@@ -83,6 +83,6 @@ var_dump($formattedResponse);
 For some very simple examples go to the samples-folder and have a look at the sample files.
 These files contain all information you need for building queries successful.
 
-##Webservice Documentation:
+## Webservice Documentation:
 Hosted on Amazon.com:
 http://docs.amazonwebservices.com/AWSECommerceService/latest/DG/


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
