### PR TITLE
Remove HHVM testing from Travis 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ matrix:
         - php: '5.6'
         - php: '7.0'
         - php: '7.1'
-        - php: hhvm
         - php: nightly
     fast_finish: true
 


### PR DESCRIPTION
<< HHVM is no longer supported on Ubuntu Precise. Please consider using Trusty with `dist: trusty`. >>