### PR TITLE
Use Ubuntu Trusty in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: php
 
 sudo: false
 
+dist: trusty
+
 matrix:
     include:
         - php: '5.6'


### PR DESCRIPTION
<< HHVM is no longer supported on Ubuntu Precise. Please consider using Trusty with dist: trusty. >>

Tests are currently failing on Travis CI due to HHVM being deprecated. One option was to remove HHVM altogether, but it's best to simply upgrade the OS. I've tested this on a fork and it works fine. Precise Pangolin is 5 years old...