### PR TITLE
Support CartCreate via SOAP

### DIFF
--- a/lib/ApaiIO/Operations/CartCreate.php
+++ b/lib/ApaiIO/Operations/CartCreate.php
@@ -41,12 +41,21 @@ class CartCreate extends AbstractOperation
      * @param string  $id       The ASIN or OfferListingId Number of the item
      * @param integer $quantity How much you want to add
      * @param bool    $byAsin   If False will use OfferListingId insted of ASIN
+     * @param bool    $asSoap   If true wrap item elements in an items element.
      */
-    public function addItem($id, $quantity, $byAsin = true)
+    public function addItem($id, $quantity, $byAsin = true, $asSoap = false)
     {
-        $itemIdentifier = ($byAsin) ? '.ASIN' : '.OfferListingId';
-        $this->parameter['Item.' . $this->itemCounter . $itemIdentifier] = $id;
-        $this->parameter['Item.' . $this->itemCounter . '.Quantity'] = $quantity;
+        $itemIdentifier = ($byAsin) ? 'ASIN' : 'OfferListingId';
+        if ($asSoap) {
+          $this->parameter['Items']['Item'][] = array(
+            $itemIdentifier => $id,
+            'Quantity' => $quantity,
+          );
+        }
+        else {
+          $this->parameter['Item.' . $this->itemCounter . $itemIdentifier] = $id;
+          $this->parameter['Item.' . $this->itemCounter . '.Quantity'] = $quantity;
+        }
 
         $this->itemCounter++;
     }


### PR DESCRIPTION
CartCreate calls over SOAP requests require a wrapping 'Items' element around 'Item' elements in a different format to those used by REST requests.

Unfortunately this is only for the 1.x branch, because our client's site is on an older version of PHP than is supported by the master branch, sorry! I'm sure the equivalent tweak in the master branch is just as simple.

As operations don't have any awareness of the request method, I couldn't think of any better way to format the request parameters than just passing in an argument from the calling code. 

Perhaps there could be some way of transforming operations per request method?? I've no idea of the best way of doing that though.